### PR TITLE
Adding basic support for linking to specific puzzles

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # Vertex
-A remake of the [discontined](https://www.nytimes.com/2024/08/08/crosswords/vertex-goodbye.html) New York Times game Vertex, using archived puzzle data from [here](https://github.com/Q726kbXuN/vertex).
+A remake of the [discontined](https://www.nytimes.com/2024/08/08/crosswords/vertex-goodbye.html) New York Times game Vertex, using archived puzzle data from [here](https://github.com/Q726kbXuN/vertex)

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,6 @@
-import './style.css'
-import testPuzzle from './test.json'
-import Hammer, { on } from 'hammerjs';
+import Hammer from 'hammerjs';
+import './style.css';
+import testPuzzle from './test.json';
 
 interface Vector { x: number, y: number };
 function sqr(x: number) { return x * x }

--- a/src/main.ts
+++ b/src/main.ts
@@ -478,7 +478,7 @@ function handleSelection() {
             closestKey = key;
         }
     }
-    if (closestKey && dist < ((1.3*getPointSize(closestKey)) / scale) ** 2) {
+    if (closestKey && dist < ((2.3*getPointSize(closestKey)) / scale) ** 2) {
         if (mouseDown) {
             clicked = puzzle.vertices[closestKey];
             clicked.selected = 1;


### PR DESCRIPTION
This is a super basic pass at adding a way to directly link to a particular puzzle via something like http://127.0.0.1:5173/2024-08-24

Could probably be improved on by having a  loading state when first populating the client with puzzle information because the select ui is essentially a no-op when a valid puzzle is provided

Could also probably add an error feedback if a bad argument is used